### PR TITLE
 now allows for the repo name to be 'origin', 'gh' or 'github'

### DIFF
--- a/octogit/core.py
+++ b/octogit/core.py
@@ -196,7 +196,7 @@ def find_github_remote():
     remotes = stdout.strip().split('\n')
     for line in remotes:
         name, url, _ = line.split()
-        if 'github.com' in url and name == 'origin':
+        if 'github.com' in url and name == 'origin' or name=='gh' or name=='github':
             return url
     else:
         puts(colored.red('This repository has no Github remotes'))


### PR DESCRIPTION
... now allows for the name 'origin', 'gh' or 'github'
