### PR TITLE
Adressing issues starting with a hash

### DIFF
--- a/octogit/cli.py
+++ b/octogit/cli.py
@@ -132,6 +132,8 @@ def begin():
                 sys.exit(0)
 
         issue_number = args.get(1)
+        if issue_number.startwith('#'):
+            issue_number = issue_number[1:]
 
         if issue_number is not None:
             if args.get(2) == 'close':


### PR DESCRIPTION
I believe that octogit should be able to respond correctly to something like this:

```
$ octogit issues #37
```

This pull request makes that possible.
