### PR TITLE
Fixing octogit issues

### DIFF
--- a/octogit/cli.py
+++ b/octogit/cli.py
@@ -132,10 +132,11 @@ def begin():
                 sys.exit(0)
 
         issue_number = args.get(1)
-        if issue_number.startwith('#'):
-            issue_number = issue_number[1:]
 
         if issue_number is not None:
+            if issue_number.startwith('#'):
+                issue_number = issue_number[1:]
+
             if args.get(2) == 'close':
                 close_issue(username, url, issue_number)
                 sys.exit(0)


### PR DESCRIPTION
The previous pull request breaks octogit in cases where issue_number is none, e.g.

```
$ octogit issues
```

This pull request fixes it
