### PR TITLE
Updated travis.yml to remove --use-mirrors deprecated attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ python:
 script: make check
 install:
     - pip install nose
-    - pip install -r requirements.txt --use-mirrors
+    - pip install -r requirements.txt


### PR DESCRIPTION
Updated .travis.yml to remove deprecated --use-mirrors flag.

This should address #88 

See https://github.com/pypa/pip/pull/1098